### PR TITLE
Fix:change command line variable's name to correct

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ python3 cha.py aggregate --help
 **Usage example:**
 
 ```bash
-python3 cha.py generate --repeats=10 --out_dir="out" --debug
+python3 cha.py generate --repeats=10 --out-dir="out" --debug
 ```
 
 ### analyze
@@ -66,7 +66,7 @@ python3 cha.py generate --repeats=10 --out_dir="out" --debug
 **Usage example:**
 
 ```bash
-python3 cha.py analyze --test_dir="out" --out_dir="perf_result" --debug
+python3 cha.py analyze --test-dir="out" --out-dir="perf_result" --debug
 ```
 
 ### summarize
@@ -74,7 +74,7 @@ python3 cha.py analyze --test_dir="out" --out_dir="perf_result" --debug
 **Usage example:**
 
 ```bash
-python3 cha.py summarize --src_dirs="perf_result" --out_dir="summarize_result" --debug
+python3 cha.py summarize --src-dirs="perf_result" --out-dir="summarize_result" --debug
 ```
 ## Development
 


### PR DESCRIPTION
Rename varriables in user-guide in README.md