### PR TITLE
Change argparse to typer and change Namespace to Dict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ pytz==2024.1
 six==1.16.0
 typing_extensions==4.12.2
 tzdata==2024.1
+typer==0.12.3

--- a/src/analyzers/backGroundBuildAnalyzer.py
+++ b/src/analyzers/backGroundBuildAnalyzer.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
-from argparse import Namespace
 
 import logging
 import shutil
 from pathlib import Path
 from tempfile import mkdtemp
-from typing import Dict
+from typing import Dict, Any
 from src.protocols.queueCollector import QueueCollector
 from src.protocols.patcher import Patcher
 
@@ -13,14 +12,14 @@ from src.helpers.backGroundBuilder import BGBuilder
 
 
 class BGBuildAnalyzer:
-    def __init__(self, patcher: Patcher, builder: BGBuilder, collector: QueueCollector, settings: Namespace):
+    def __init__(self, patcher: Patcher, builder: BGBuilder, collector: QueueCollector, settings: Dict[str, Any]):
         self.settings = settings
         self.patcher = patcher
         self.collector = collector
         self.builder = builder
 
         self.logger = logging.getLogger(__name__)
-        self.logger.setLevel(self.settings.log_level)
+        self.logger.setLevel(self.settings["log_level"])
 
         self.temp_dir: Path = Path(mkdtemp())
 

--- a/src/analyzers/baseAnalyzer.py
+++ b/src/analyzers/baseAnalyzer.py
@@ -1,9 +1,8 @@
 import logging
 import shutil
-from argparse import Namespace
 from pathlib import Path
 from tempfile import mkdtemp
-from typing import Dict
+from typing import Dict, Any
 
 from src.helpers.builder import Builder
 from src.protocols.collector import Collector, DictSI
@@ -16,7 +15,7 @@ class BaseAnalyzer:
         patcher: Patcher,
         builder: Builder,
         collector: Collector,
-        settings: Namespace,
+        settings: Dict[str, Any],
     ):
         self.settings = settings
         self.patcher = patcher
@@ -24,7 +23,7 @@ class BaseAnalyzer:
         self.builder = builder
 
         self.logger = logging.getLogger(__name__)
-        self.logger.setLevel(self.settings.log_level)
+        self.logger.setLevel(self.settings["log_level"])
 
         self.temp_dir: Path = Path(mkdtemp())
 

--- a/src/analyzers/collectors/gemCollector.py
+++ b/src/analyzers/collectors/gemCollector.py
@@ -3,9 +3,8 @@ import re
 import shlex
 import signal
 import subprocess
-from argparse import Namespace
 from pathlib import Path
-from typing import Dict, Set
+from typing import Dict, Set, Any
 
 from src.protocols.collector import DictSI
 
@@ -13,25 +12,25 @@ from src.protocols.collector import DictSI
 class GemCollector:
     BINARY_PLACEHOLDER = "{{GEM5_TARGET_BINARY}}"
 
-    def __init__(self, settings: Namespace):
+    def __init__(self, settings: Dict[str, Any]):
         self.settings = settings
         self.logger = logging.getLogger(__name__)
-        self.logger.setLevel(self.settings.log_level)
+        self.logger.setLevel(self.settings["log_level"])
 
-        self.gem5_home = Path(self.settings.__dict__.get("gem5_home", ""))
-        self.target_isa = self.settings.__dict__.get("target_isa", "").lower()
+        self.gem5_home = Path(self.settings.get("gem5_home", ""))
+        self.target_isa = self.settings.get("target_isa", "").lower()
 
-        self.gem5_bin_path = self.settings.__dict__.get(
+        self.gem5_bin_path = self.settings.get(
             "gem5_bin_path",
             self.gem5_home.joinpath("build", self.target_isa.upper(), "gem5.opt"),
         )
 
-        self.sim_script_path = self.settings.__dict__.get(
+        self.sim_script_path = self.settings.get(
             "sim_script_path",
             self.gem5_home.joinpath("configs/deprecated/example/se.py"),
         )
 
-        self.sim_script_args = self.settings.__dict__.get(
+        self.sim_script_args = self.settings.get(
             "sim_script_args", f"--cpu-type=O3CPU --caches -c {self.BINARY_PLACEHOLDER}"
         )
         self.sim_script_args = shlex.split(self.sim_script_args)
@@ -84,7 +83,7 @@ class GemCollector:
 
             proc = subprocess.Popen(execute_line, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             try:
-                proc.wait(self.settings.timeout)
+                proc.wait(self.settings["timeout"])
             except subprocess.TimeoutExpired:
                 proc.send_signal(signal.SIGINT)
                 is_full_run = False

--- a/src/analyzers/collectors/perfCollector.py
+++ b/src/analyzers/collectors/perfCollector.py
@@ -3,9 +3,8 @@ import signal
 import subprocess
 import sys
 import time
-from argparse import Namespace
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, List
+from typing import TYPE_CHECKING, Dict, List, Any
 
 if TYPE_CHECKING:
     from _typeshed import StrOrBytesPath
@@ -15,14 +14,13 @@ from src.protocols.collector import DictSI
 
 
 class PerfCollector:
-    def __init__(self, settings: Namespace):
+    def __init__(self, settings: Dict[str, Any]):
         self.settings = settings
         self.logger = logging.getLogger(__name__)
-        self.logger.setLevel(self.settings.log_level)
+        self.logger.setLevel(self.settings["log_level"])
 
-        set_dict = vars(settings)
-        self.max_test_launches = set_dict.get("max_test_launches", -1)
-        self.cpu = set_dict.get("cpu", 0)
+        self.max_test_launches = settings.get("max_test_launches", -1)
+        self.cpu = settings.get("cpu", 0)
 
     def tab_lines(self, lines: str) -> str:
         return "\t" + lines.replace("\n", "\n\t")[:-1]
@@ -66,8 +64,8 @@ class PerfCollector:
         execute_string = " ".join(map(str, execute_line))
         self.logger.info(f"[perfProfiler]: Executing: {execute_string}")
 
-        left_time = self.settings.timeout
-        timeout = time.time() + self.settings.timeout
+        left_time = self.settings["timeout"]
+        timeout = time.time() + self.settings["timeout"]
         while (left_time > 0) and (number_executes != 0):
             stats.append(self.execute_test(execute_line, left_time))
             left_time = timeout - time.time()

--- a/src/analyzers/collectors/sshCollector.py
+++ b/src/analyzers/collectors/sshCollector.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-from argparse import Namespace
 from queue import Queue
 import logging
 import random
@@ -7,7 +6,7 @@ import stat
 from pathlib import Path
 import sys
 import time
-from typing import Dict, List
+from typing import Dict, List, Any
 
 import paramiko
 
@@ -16,20 +15,19 @@ from src.helpers.backGroundBuilder import CSignal
 
 
 class SshCollector:
-    def __init__(self, settings: Namespace, bin_dir: Path | None = None):
+    def __init__(self, settings: Dict[str, Any], bin_dir: Path | None = None):
         self.settings = settings
         self.logger = logging.getLogger(__name__)
-        self.logger.setLevel(self.settings.log_level)
+        self.logger.setLevel(self.settings["log_level"])
         self.is_tmp_created = False
 
-        set_dict = vars(settings)
-        self.max_test_launches = set_dict.get("max_test_launches", -1)
-        self.cpu = set_dict.get("cpu", 0)
+        self.max_test_launches = settings.get("max_test_launches", -1)
+        self.cpu = settings.get("cpu", 0)
 
-        self.host = set_dict.get("host", "127.0.0.1")
-        self.user = set_dict.get("username", "root")
-        self.path_to_key = set_dict.get("path_to_key", "~/.ssh/id_rsa")
-        self.password = set_dict.get("password", "toor")
+        self.host = settings.get("host", "127.0.0.1")
+        self.user = settings.get("username", "root")
+        self.path_to_key = settings.get("path_to_key", "~/.ssh/id_rsa")
+        self.password = settings.get("password", "toor")
 
         self.open()
 
@@ -137,8 +135,8 @@ class SshCollector:
         execute_string = " ".join(map(str, execute_line))
         self.logger.info(f"[sshProfiler]: Executing: {execute_string}")
 
-        left_time = self.settings.timeout
-        timeout = time.time() + self.settings.timeout
+        left_time = self.settings["timeout"]
+        timeout = time.time() + self.settings["timeout"]
         while (left_time > 0) and (number_executes != 0):
             stats.append(self.execute_test(execute_line, left_time))
             left_time = timeout - time.time()

--- a/src/analyzers/gemAnalyzer.py
+++ b/src/analyzers/gemAnalyzer.py
@@ -1,7 +1,6 @@
 import logging
-from argparse import Namespace
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Any
 
 from src.analyzers.baseAnalyzer import BaseAnalyzer
 from src.analyzers.collectors.gemCollector import GemCollector
@@ -12,14 +11,14 @@ from src.protocols.collector import DictSI
 
 
 class GemAnalyzer:
-    def __init__(self, builder: Builder, settings: Namespace):
+    def __init__(self, builder: Builder, settings: Dict[str, Any]):
         self.settings = settings
         self.builder: Builder = builder
         self.logger = logging.getLogger(__name__)
-        self.logger.setLevel(self.settings.log_level)
+        self.logger.setLevel(self.settings["log_level"])
 
-        self.gem5_home = Path(self.settings.__dict__.get("gem5_home", ""))
-        self.target_isa = self.settings.__dict__.get("target_isa", "").lower()
+        self.gem5_home = Path(self.settings.get("gem5_home", ""))
+        self.target_isa = self.settings.get("target_isa", "").lower()
 
         self.build_additional_flags = [
             f"-I{self.gem5_home.joinpath('include')}",

--- a/src/analyzers/patchers/basePatcher.py
+++ b/src/analyzers/patchers/basePatcher.py
@@ -1,18 +1,18 @@
 import glob
 import logging
 import sys
-from argparse import Namespace
 from pathlib import Path
+from typing import Dict, Any
 
 ATTACH_DIR = "src/analyzers/patchers/attachments/"
 
 
 class BasePatcher:
-    def __init__(self, settings: Namespace, templates: list[str]):
+    def __init__(self, settings: Dict[str, Any], templates: list[str]):
         self.settings = settings
 
         self.logger = logging.getLogger(__name__)
-        self.logger.setLevel(self.settings.log_level)
+        self.logger.setLevel(self.settings["log_level"])
 
         launch_dir = Path(sys.argv[0]).parent
         self.empty_test_path = launch_dir.joinpath(ATTACH_DIR, "empty.c")

--- a/src/analyzers/patchers/gemPatcher.py
+++ b/src/analyzers/patchers/gemPatcher.py
@@ -1,15 +1,15 @@
 import logging
-from argparse import Namespace
 from pathlib import Path
+from typing import Dict, Any
 
 from src.analyzers.patchers.basePatcher import BasePatcher
 
 
 class GemPatcher:
-    def __init__(self, settings: Namespace):
+    def __init__(self, settings: Dict[str, Any]):
         self.settings = settings
         self.logger = logging.getLogger(__name__)
-        self.logger.setLevel(self.settings.log_level)
+        self.logger.setLevel(self.settings["log_level"])
 
         self.patcher = BasePatcher(settings, ["gemTemplate.c"])
 

--- a/src/analyzers/patchers/perfPatcher.py
+++ b/src/analyzers/patchers/perfPatcher.py
@@ -1,18 +1,17 @@
 import logging
-from argparse import Namespace
 from pathlib import Path
+from typing import Dict, Any
 
 from src.analyzers.patchers.basePatcher import BasePatcher
 
 
 class PerfPatcher:
-    def __init__(self, settings: Namespace):
+    def __init__(self, settings: Dict[str, Any]):
         self.settings = settings
         self.logger = logging.getLogger(__name__)
-        self.logger.setLevel(self.settings.log_level)
+        self.logger.setLevel(self.settings["log_level"])
 
-        settings_dict = vars(settings)
-        events_file: str = settings_dict.get("events", "classic.c")
+        events_file: str = settings.get("events", "classic.c")
         events_file = "perf_events/" + events_file
 
         self.patcher = BasePatcher(settings, [events_file, "perfTemplate.c"])

--- a/src/analyzers/perfAnalyzer.py
+++ b/src/analyzers/perfAnalyzer.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
 import logging
-from argparse import Namespace
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Any
 
 from src.analyzers.baseAnalyzer import BaseAnalyzer
 from src.analyzers.collectors.perfCollector import PerfCollector
@@ -14,11 +13,11 @@ from src.protocols.collector import DictSI
 
 
 class PerfAnalyzer:
-    def __init__(self, builder: Builder, settings: Namespace):
+    def __init__(self, builder: Builder, settings: Dict[str, Any]):
         self.settings = settings
         self.builder: Builder = builder
         self.logger = logging.getLogger(__name__)
-        self.logger.setLevel(self.settings.log_level)
+        self.logger.setLevel(self.settings["log_level"])
 
         self.base: Analyzer = BaseAnalyzer(PerfPatcher(settings), self.builder, PerfCollector(settings), settings)
 

--- a/src/analyzers/sshAnalyzer.py
+++ b/src/analyzers/sshAnalyzer.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
-from argparse import Namespace
 import logging
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Any
 
 from src.analyzers.backGroundBuildAnalyzer import BGBuildAnalyzer
 from src.analyzers.collectors.sshCollector import SshCollector
@@ -12,11 +11,11 @@ from src.protocols.analyzer import Analyzer
 
 
 class SshAnalyzer:
-    def __init__(self, builder: BGBuilder, settings: Namespace):
+    def __init__(self, builder: BGBuilder, settings: Dict[str, Any]):
         self.settings = settings
         self.builder: BGBuilder = builder
         self.logger = logging.getLogger(__name__)
-        self.logger.setLevel(self.settings.log_level)
+        self.logger.setLevel(self.settings["log_level"])
 
         self.collector: SshCollector = SshCollector(settings)
         self.base: Analyzer = BGBuildAnalyzer(PerfPatcher(settings), self.builder, self.collector, settings)

--- a/src/cli/aggregate.py
+++ b/src/cli/aggregate.py
@@ -17,6 +17,37 @@ class Aggregate(Utility):
     def __init__(self) -> None:
         self.settings: Dict[str, Any] = {}
         self.logger = logging.getLogger(__name__)
+        self.default_analyze_settings = {
+            "utility": "analyze",
+            "config_file": None,
+            "out_dir": "analyze",
+            "test_dir": "tests",
+            "timeout": 10,
+            "compiler": "gcc",
+            "compiler_args": "",
+            "profiler": "perf",
+            "gem5_home": "./",
+            "gem5_bin": "./",
+            "target_isa": "",
+            "sim_script": "./",
+            "log_level": "WARNING",
+        }
+
+        self.default_generate_settings = {
+            "utility": "generate",
+            "out_dir": "tests",
+            "repeats": 1,
+            "log_level": "WARNING"
+        }
+
+        self.default_summarize_settings = {
+            "utility": "summarize",
+            "src_dirs": None,
+            "out_dir": "summarize",
+            "no_show_graph": False,
+            "no_save_graph": False,
+            "log_level": "WARNING",
+        }
 
     def _run_analyzer(self, analyze: Analyze, chan: Queue):
         analyze.run()

--- a/src/cli/aggregate.py
+++ b/src/cli/aggregate.py
@@ -3,34 +3,33 @@ import os
 import shlex
 import shutil
 import threading
-from argparse import ArgumentParser, Namespace
 from datetime import datetime
 from pathlib import Path
 from pprint import pformat
 from queue import Queue
-from typing import List
+from typing import List, Dict, Any
 
 from src.cli.analyze import Analyze
-from src.protocols.subparser import SubParser
+from src.protocols.utility import Utility
 
 
-class Aggregate:
+class Aggregate(Utility):
     def __init__(self) -> None:
-        self.settings = Namespace()
+        self.settings: Dict[str, Any] = {}
         self.logger = logging.getLogger(__name__)
 
     def _run_analyzer(self, analyze: Analyze, chan: Queue):
         analyze.run()
         if analyze.settings is None:
             raise LookupError("Didn't find settings for analyze")
-        chan.put(analyze.settings.out_dir)
+        chan.put(analyze.settings["out_dir"])
 
     # TODO: this is a draft method and should be removed or rewritted with asincio
     def run_analyzers(self) -> List[str]:
         output_analyze_dirs: List[str] = []
         chan = Queue()
         for analyze in self.analyzes:
-            if self.settings.async_analyze:
+            if self.settings["async_analyze"]:
                 threading.Thread(target=self._run_analyzer, args=(analyze, chan)).start()
             else:
                 self._run_analyzer(analyze, chan)
@@ -40,98 +39,65 @@ class Aggregate:
 
         return output_analyze_dirs
 
-    def create_analyzer(self, config_file: Path, settings_analyze: Namespace) -> Analyze:
+    def create_analyzer(self, config_file: Path, settings_analyze: Dict[str, Any]) -> Analyze:
         analyze = Analyze()
-        full_conf_path = Path(self.settings.path_to_configs).joinpath(config_file)
+        full_conf_path = Path(self.settings["path_to_configs"]).joinpath(config_file)
         if os.access(full_conf_path, mode=os.R_OK):
-            cfg_settings = self.settings.configurator.read_cfg_file(full_conf_path)
-            settings_analyze = Namespace(
-                **self.settings.configurator.get_true_settings(
-                    self.settings.analyze.analyze_parser,
+            cfg_settings = self.settings["configurator"].read_cfg_file(full_conf_path)
+            settings_analyze = self.settings["configurator"].get_true_settings(
                     cfg_settings,
                     settings_analyze,
                 )
-            )
             # if user set absolute path in config, we will save by it
-            if not Path(settings_analyze.out_dir).is_absolute():
+            if not Path(settings_analyze["out_dir"]).is_absolute():
                 name = full_conf_path.name.split(".")[0]
                 sub_dir_name = f"{name}-{datetime.now().strftime('%y-%m-%d-%H-%M-%S-%f')}"
-                sub_dir = Path(self.settings.dest_dir).joinpath(sub_dir_name)
+                sub_dir = Path(self.settings["dest_dir"]).joinpath(sub_dir_name)
                 while sub_dir.exists():
                     sub_dir_name = sub_dir_name + "_new"
                     sub_dir = sub_dir.with_name(sub_dir_name)
-                settings_analyze.out_dir = sub_dir.joinpath(settings_analyze.out_dir)
+                settings_analyze["out_dir"] = sub_dir.joinpath(settings_analyze["out_dir"])
 
-            settings_analyze.log_level = self.settings.log_level
+            settings_analyze["log_level"] = self.settings["log_level"]
             analyze.configurate(settings_analyze)
 
         return analyze
 
     def clean_output_dir(self) -> None:
-        shutil.rmtree(self.settings.dest_dir)
+        shutil.rmtree(self.settings["dest_dir"])
 
     def run(self) -> None:
         self.logger.info("Aggregate is running. Settings:")
-        self.logger.info(pformat(vars(self.settings)))
+        self.logger.info(pformat(self.settings))
 
         # configure and run generator
-        args_generate = shlex.split(self.settings.Wg)
-        settings_generate = self.settings.generate.parse_args(args_generate)
-        settings_generate.log_level = self.settings.log_level
+        args_generate = shlex.split(self.settings["Wg"])
+        configurator = self.settings["configurator"]
+        settings_generate = configurator.parse_args(args_generate, self.settings["generate"].default_params)
+        settings_generate["log_level"] = self.settings["log_level"]
 
-        self.settings.generate.configurate(settings_generate)
-        self.settings.generate.run()
+        self.settings["generate"].configurate(settings_generate)
+        self.settings["generate"].run()
 
         # configure and run analyzer
         self.output_analyze_dirs = self.run_analyzers()
 
         # configure and run summarizer
-        args_summarize = shlex.split(self.settings.Ws)
-        settings_summarize = self.settings.summarize.parse_args(args_summarize)
-        settings_summarize.src_dirs = self.output_analyze_dirs
-        settings_summarize.log_level = self.settings.log_level
-        settings_summarize.out_dir = Path(self.settings.dest_dir).joinpath(settings_summarize.out_dir)
+        args_summarize = shlex.split(self.settings["Ws"])
+        settings_summarize = configurator.parse_args(args_summarize, self.settings["summarize"].default_params)
+        settings_summarize["src_dirs"] = self.output_analyze_dirs
+        settings_summarize["log_level"] = self.settings["log_level"]
+        settings_summarize["out_dir"] = Path(self.settings["dest_dir"]).joinpath(settings_summarize["out_dir"])
 
-        self.settings.summarize.configurate(settings_summarize)
-        self.settings.summarize.run()
+        self.settings["summarize"].configurate(settings_summarize)
+        self.settings["summarize"].run()
 
-    def configurate(self, settings: Namespace) -> None:
-        self.settings = Namespace(**{**vars(settings), **vars(self.settings)})
-        self.logger.setLevel(self.settings.log_level)
+    def configurate(self, settings: Dict[str, Any]) -> None:
+        self.settings = {**self.settings, **settings}
+        self.logger.setLevel(self.settings["log_level"])
 
         # TODO: this is draft and should be rewritted
-        args_analyze = shlex.split(self.settings.Wz)
-        settings_analyze = self.settings.analyze.parse_args(args_analyze)
-        self.analyzes = [self.create_analyzer(cfg, settings_analyze) for cfg in self.settings.configs]
-
-    def add_parser_arguments(self, subparser: SubParser) -> ArgumentParser:
-        shell_parser: ArgumentParser = subparser.add_parser("aggregate", prog="aggregate")
-
-        shell_parser.add_argument("--config-file", default="config.json", help="Path to .cfg file")
-        shell_parser.add_argument(
-            "--section-in-config",
-            default="DEFAULT",
-            help="Set the custom section in config file (DEFAULT by default)",
-        )
-        shell_parser.add_argument(
-            "--dest-dir",
-            default="out",
-            help="Path to dist dir, if not exit it will be created",
-        )
-        shell_parser.add_argument(
-            "--async-analyze", action="store_true", help="Run analyze steps simultaneously (not recommended with perf)"
-        )
-        shell_parser.add_argument("--Wg", default="", help="Pass arguments to generate")
-        shell_parser.add_argument("--Wz", default="", help="Pass arguments to analyze")
-        shell_parser.add_argument("--Ws", default="", help="Pass arguments to summarize")
-        shell_parser.add_argument(
-            "--log-level",
-            default="WARNING",
-            choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
-            help="Log level of program",
-        )
-        self.shell_parser = shell_parser
-        return shell_parser
-
-    def parse_args(self, args: List[str]) -> Namespace:
-        return self.shell_parser.parse_known_args(args)[0]
+        args_analyze = shlex.split(self.settings["Wz"])
+        configurator = self.settings["configurator"]
+        settings_analyze = configurator.parse_args(args_analyze, self.settings["analyze"].default_params)
+        self.analyzes = [self.create_analyzer(cfg, settings_analyze) for cfg in self.settings["configs"]]

--- a/src/cli/analyze.py
+++ b/src/cli/analyze.py
@@ -73,19 +73,3 @@ class Analyze(Utility):
     def pack(self, analyze_dir: Path, analyzed_data: Dict[str, DictSI]) -> None:
         print(f"[+]: Save analysis' results to {analyze_dir.absolute().as_posix()}")
         self.packer.pack(analyze_dir, analyzed_data)
-
-    default_params = {
-        "utility": "analyze",
-        "config_file": None,
-        "out_dir": "analyze",
-        "test_dir": "tests",
-        "timeout": 10,
-        "compiler": "gcc",
-        "compiler_args": "",
-        "profiler": "perf",
-        "gem5_home": "./",
-        "gem5_bin": "./",
-        "target_isa": "",
-        "sim_script": "./",
-        "log_level": "WARNING",
-    }

--- a/src/cli/analyze.py
+++ b/src/cli/analyze.py
@@ -1,10 +1,9 @@
 import logging
 import shlex
 import shutil
-from argparse import ArgumentParser, Namespace
 from pathlib import Path
 from pprint import pformat
-from typing import Dict, List
+from typing import Dict, Any
 
 from src.analyzers.gemAnalyzer import GemAnalyzer
 from src.analyzers.perfAnalyzer import PerfAnalyzer
@@ -14,27 +13,27 @@ from src.helpers.builder import Builder
 from src.helpers.packer import Packer
 from src.protocols.analyzer import Analyzer
 from src.protocols.collector import DictSI
-from src.protocols.subparser import SubParser
+from src.protocols.utility import Utility
 
 
-class Analyze:
+class Analyze(Utility):
     def __init__(self) -> None:
         self.analyzer: Analyzer | None = None
         self.packer = Packer()
         self.builder: Builder | None = None
         self.test_dir: Path | None = None
         self.analyze_dir: Path | None = None
-        self.settings: Namespace | None = None
+        self.settings: Dict[str, Any] | None = None
         self.logger = logging.getLogger(__name__)
 
-    def configurate(self, settings: Namespace) -> None:
+    def configurate(self, settings: Dict[str, Any]) -> None:
         self.settings = settings
-        self.logger.setLevel(self.settings.log_level)
-        self.test_dir = Path(settings.test_dir)
-        self.analyze_dir = Path(settings.out_dir)
-        self.settings.compiler_args = shlex.split(settings.compiler_args)
+        self.logger.setLevel(self.settings["log_level"])
+        self.test_dir = Path(settings["test_dir"])
+        self.analyze_dir = Path(settings["out_dir"])
+        self.settings["compiler_args"] = shlex.split(settings["compiler_args"])
         self.builder = Builder(self.settings)
-        match settings.profiler:
+        match settings["profiler"]:
             case "perf":
                 self.analyzer = PerfAnalyzer(self.builder, settings)
             case "gem5":
@@ -42,11 +41,11 @@ class Analyze:
             case "ssh":
                 self.analyzer = SshAnalyzer(BGBuilder(settings, self.builder), settings)
             case _:
-                raise Exception(f'"{settings.profiler}" is unknown profiler')
+                raise Exception(f'"{settings["profiler"]}" is unknown profiler')
 
     def run(self) -> None:
         self.logger.info("Analyze running. Settings:")
-        self.logger.info(pformat(vars(self.settings)))
+        self.logger.info(pformat(self.settings))
         if self.analyze_dir is None or self.test_dir is None:
             self.logger.warn("analyze_dir or test_dir are partially unknown. Exiting...")
             return
@@ -75,36 +74,18 @@ class Analyze:
         print(f"[+]: Save analysis' results to {analyze_dir.absolute().as_posix()}")
         self.packer.pack(analyze_dir, analyzed_data)
 
-    def add_parser_arguments(self, subparser: SubParser) -> ArgumentParser:
-        analyze_parser: ArgumentParser = subparser.add_parser("analyze")
-        analyze_parser.add_argument("--config-file", default=None, help="Path to config file")
-        analyze_parser.add_argument("--out-dir", default="analyze", help="Path to output dir")
-        analyze_parser.add_argument("--test-dir", default="tests", help="Path to directory with tests")
-        analyze_parser.add_argument(
-            "--timeout",
-            default=10,
-            help="Number of seconds after which the test will be stopped",
-        )
-        analyze_parser.add_argument("--compiler", default="gcc", help="Path to compiler")
-        analyze_parser.add_argument("--compiler-args", default="", help="Pass arguments on to the compiler")
-        analyze_parser.add_argument(
-            "--profiler",
-            choices=["perf", "gem5"],
-            default="perf",
-            help="Type of profiler",
-        )
-        analyze_parser.add_argument("--gem5-home", default="./", help="Path to home gem5")
-        analyze_parser.add_argument("--gem5-bin", default="./", help="Path to execute gem5")
-        analyze_parser.add_argument("--target-isa", default="", help="Type of architecture being simulated")
-        analyze_parser.add_argument("--sim-script", default="./", help="Path to simulation Script")
-        analyze_parser.add_argument(
-            "--log-level",
-            default="WARNING",
-            choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
-            help="Log level of program",
-        )
-        self.analyze_parser = analyze_parser
-        return analyze_parser
-
-    def parse_args(self, args: List[str]) -> Namespace:
-        return self.analyze_parser.parse_known_args(args)[0]
+    default_params = {
+        "utility": "analyze",
+        "config_file": None,
+        "out_dir": "analyze",
+        "test_dir": "tests",
+        "timeout": 10,
+        "compiler": "gcc",
+        "compiler_args": "",
+        "profiler": "perf",
+        "gem5_home": "./",
+        "gem5_bin": "./",
+        "target_isa": "",
+        "sim_script": "./",
+        "log_level": "WARNING",
+    }

--- a/src/cli/generate.py
+++ b/src/cli/generate.py
@@ -52,10 +52,3 @@ class Generate(Utility):
             return
         self.create_empty_dir(self.out_dir)
         self.generate_tests(self.out_dir, self.repeats)
-
-    default_params = {
-        "utility": "generate",
-        "out_dir": "tests",
-        "repeats": 1,
-        "log_level": "WARNING"
-    }

--- a/src/cli/generate.py
+++ b/src/cli/generate.py
@@ -1,26 +1,24 @@
 import logging
 import shutil
-from argparse import ArgumentParser, Namespace
 from pathlib import Path
 from pprint import pformat
-from typing import List, Optional
-
+from typing import Optional, Any, Dict
 from src.generators.code_gen import gen_test
-from src.protocols.subparser import SubParser
+from src.protocols.utility import Utility
 
 
-class Generate:
+class Generate(Utility):
     def __init__(self) -> None:
-        self.settings: Optional[Namespace] = None
+        self.settings: Optional[Dict[str, Any]] = None
         self.repeats: Optional[int] = None
         self.out_dir: Optional[Path] = None
         self.logger = logging.getLogger(__name__)
 
-    def configurate(self, settings: Namespace) -> None:
+    def configurate(self, settings: Dict[str, Any]) -> None:
         self.settings = settings
-        self.logger.setLevel(self.settings.log_level)
-        self.out_dir = Path(settings.out_dir)
-        self.repeats = int(settings.repeats)
+        self.logger.setLevel(self.settings["log_level"])
+        self.out_dir = Path(settings["out_dir"])
+        self.repeats = int(settings["repeats"])
 
     def generate_tests(
         self,
@@ -35,7 +33,7 @@ class Generate:
     def _generate_test(self, file: Path, max_depth: int) -> None:
         test = gen_test(max_depth)
         if file.is_dir():
-            self.logger.warn(f"Provided path {file} are not a file. Skipping this test.")
+            self.logger.warn(f"Provided path {file} is not a file. Skipping this test.")
             return
         with open(file, "w") as f:
             self.logger.info(f"Write test into {file}")
@@ -48,25 +46,16 @@ class Generate:
 
     def run(self) -> None:
         self.logger.info("Generate is running. Settings:")
-        self.logger.info(pformat(vars(self.settings)))
+        self.logger.info(pformat(self.settings))
         if self.out_dir is None or self.repeats is None:
             self.logger.warn("Out dir or repeats values are not provided. Exiting...")
             return
         self.create_empty_dir(self.out_dir)
         self.generate_tests(self.out_dir, self.repeats)
 
-    def add_parser_arguments(self, subparser: SubParser) -> ArgumentParser:
-        generate_parser = subparser.add_parser("generate")
-        generate_parser.add_argument("--out-dir", default="tests", help="Path to output dir")
-        generate_parser.add_argument("--repeats", type=int, default=1, help="Count of repeats to generated test")
-        generate_parser.add_argument(
-            "--log-level",
-            default="WARNING",
-            choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
-            help="Log level of program",
-        )
-        self.generate_parser = generate_parser
-        return generate_parser
-
-    def parse_args(self, args: List[str]) -> Namespace:
-        return self.generate_parser.parse_known_args(args)[0]
+    default_params = {
+        "utility": "generate",
+        "out_dir": "tests",
+        "repeats": 1,
+        "log_level": "WARNING"
+    }

--- a/src/cli/summarize.py
+++ b/src/cli/summarize.py
@@ -242,12 +242,3 @@ class Summarize(Utility):
     def save_plot(self, out_dir: Path) -> None:
         out_dir.mkdir(parents=True, exist_ok=True)
         plt.savefig(out_dir.joinpath(self.filename_out_grapg))
-
-    default_params = {
-        "utility": "summarize",
-        "src_dirs": None,
-        "out_dir": "summarize",
-        "no_show_graph": False,
-        "no_save_graph": False,
-        "log_level": "WARNING",
-    }

--- a/src/helpers/backGroundBuilder.py
+++ b/src/helpers/backGroundBuilder.py
@@ -1,11 +1,10 @@
 from dataclasses import dataclass
 import logging
 import os
-from argparse import Namespace
 from pathlib import Path
 from queue import Queue
 import threading
-from typing import TypeAlias
+from typing import TypeAlias, Dict, Any
 
 from src.helpers.builder import Builder
 
@@ -23,10 +22,10 @@ ChanSignal: TypeAlias = CSignal.BuiltFile | CSignal.End
 
 
 class BGBuilder:
-    def __init__(self, settings: Namespace, builder: Builder | None = None):
+    def __init__(self, settings: Dict[str, Any], builder: Builder | None = None):
         self.settings = settings
         self.logger = logging.getLogger(__name__)
-        self.logger.setLevel(self.settings.log_level)
+        self.logger.setLevel(self.settings["log_level"])
 
         self.builder_mutex = threading.Lock()
         if builder is None:

--- a/src/helpers/builder.py
+++ b/src/helpers/builder.py
@@ -1,15 +1,15 @@
 import logging
 import os
 import subprocess
-from argparse import Namespace
 from pathlib import Path
+from typing import Dict, Any
 
 
 class Builder:
-    def __init__(self, settings: Namespace):
+    def __init__(self, settings: Dict[str, Any]):
         self.settings = settings
         self.logger = logging.getLogger(__name__)
-        self.logger.setLevel(self.settings.log_level)
+        self.logger.setLevel(self.settings["log_level"])
         self.default_additional_flags: list[str] = []
 
     def set_default_additional_flags(self, additional_flags: list[str]) -> None:
@@ -26,8 +26,8 @@ class Builder:
 
         destination_file.parent.mkdir(parents=True, exist_ok=True)
         execute_line = (
-            [self.settings.compiler, src_file]
-            + self.settings.compiler_args
+            [self.settings["compiler"], src_file]
+            + self.settings["compiler_args"]
             + ["-o", destination_file]
             + additional_flags
         )

--- a/src/helpers/configurator.py
+++ b/src/helpers/configurator.py
@@ -44,7 +44,7 @@ class Configurator:
         return config if section is None else {**config["DEFAULT"], **config[section]}
 
     def get_true_settings(self, settings: Dict[str, Any], args: Dict[str, Any]) -> Dict[str, Any]:
-        """Get the final settings by updating the default settings with the provided arguments
+        """Get the final settings by updating the default settings with the configs settings
 
         :param settings: Default settings
         :param args: Provided arguments to override the default settings

--- a/src/helpers/configurator.py
+++ b/src/helpers/configurator.py
@@ -1,5 +1,19 @@
 import json
+from enum import Enum
 from typing import Any, Dict, List
+
+
+class LogLevel(str, Enum):
+    DEBUG = "DEBUG"
+    INFO = "INFO"
+    WARNING = "WARNING"
+    ERROR = "ERROR"
+    CRITICAL = "CRITICAL"
+
+
+class ProfilerType(str, Enum):
+    PERF = "perf"
+    GEM5 = "gem5"
 
 
 class Configurator:

--- a/src/helpers/configurator.py
+++ b/src/helpers/configurator.py
@@ -17,7 +17,12 @@ class ProfilerType(str, Enum):
 
 
 class Configurator:
+    """Class for handling configuration files and argument parsing"""
     def configurate(self, args: Dict[str, Any]):
+        """Update the provided arguments with configuration file contents if specified
+
+        :param args: Dictionary of arguments
+        """
         config_file = args.get("config_file")
         section_in_config = args.get("section_in_config")
 
@@ -26,6 +31,12 @@ class Configurator:
             args.update(config)
 
     def read_cfg_file(self, config_file: str | None, section: str | None = None) -> Dict[str, Any]:
+        """Read a configuration file and return its contents
+
+        :param config_file: Path to the configuration file
+        :param section: Specific section in the configuration file to read
+        :return: Dictionary of configuration settings
+        """
         if config_file is None:
             return dict()
         with open(config_file, mode="r") as f:
@@ -33,6 +44,12 @@ class Configurator:
         return config if section is None else {**config["DEFAULT"], **config[section]}
 
     def get_true_settings(self, settings: Dict[str, Any], args: Dict[str, Any]) -> Dict[str, Any]:
+        """Get the final settings by updating the default settings with the provided arguments
+
+        :param settings: Default settings
+        :param args: Provided arguments to override the default settings
+        :return: Updated settings
+        """
         result: Dict[str, Any] = settings
         for arg in args:
             if arg in settings:
@@ -43,6 +60,12 @@ class Configurator:
         return result
 
     def parse_args(self, args: List[str], default_params: Dict[str, Any]) -> Dict[str, Any]:
+        """Parse command line arguments and update the default parameters
+
+       :param args: List of command line arguments
+       :param default_params: Default parameters to update
+       :return: Updated parameters
+       """
         for i in range(0, len(args), 2):
             key = args[i].lstrip("--").replace("-", "_")
             value = args[i + 1]

--- a/src/helpers/configurator.py
+++ b/src/helpers/configurator.py
@@ -1,6 +1,6 @@
 import json
 from enum import Enum
-from typing import Any, Dict, List
+from typing import Any, Dict
 
 
 class LogLevel(str, Enum):
@@ -58,18 +58,3 @@ class Configurator:
             else:
                 settings[arg] = args[arg]
         return result
-
-    def parse_args(self, args: List[str], default_params: Dict[str, Any]) -> Dict[str, Any]:
-        """Parse command line arguments and update the default parameters
-
-       :param args: List of command line arguments
-       :param default_params: Default parameters to update
-       :return: Updated parameters
-       """
-        for i in range(0, len(args), 2):
-            key = args[i].lstrip("--").replace("-", "_")
-            value = args[i + 1]
-            if key in default_params:
-                default_params[key] = value
-
-        return default_params

--- a/src/helpers/configurator.py
+++ b/src/helpers/configurator.py
@@ -1,40 +1,15 @@
 import json
-from argparse import ArgumentParser, Namespace
-from typing import Any, Dict, Optional
-
-from src.protocols.utility import Utility
+from typing import Any, Dict, List
 
 
 class Configurator:
-    def __init__(self) -> None:
-        self.args: Optional[Namespace] = None
+    def configurate(self, args: Dict[str, Any]):
+        config_file = args.get("config_file")
+        section_in_config = args.get("section_in_config")
 
-        self.parser = ArgumentParser(
-            description="This script generate and test code on some platforms",
-        )
-
-        self.sub_parser = self.parser.add_subparsers(
-            required=True,
-            title="analyze and summarize",
-            help="aggregate is shell above: analyze (code generator + profiler), summarize",
-            dest="name_of_subparsers",
-            metavar="utility {aggregate, generate, analyze, summarize}",
-        )
-
-    def parse_sub_parsers(self, utilities: Dict[str, Utility]) -> tuple[Namespace, list[str]]:
-        for name, utility in utilities.items():
-            utility.add_parser_arguments(self.sub_parser).set_defaults(utility=name)
-
-        return self.parser.parse_known_args()
-
-    def configurate(self, utilities: Dict[str, Utility]) -> Namespace:
-        self.args = self.parse_sub_parsers(utilities)[0]
-        config = self.read_cfg_file(
-            getattr(self.args, "config_file", None),
-            self.args.section_in_config if hasattr(self.args, "section_in_config") else None,
-        )
-
-        return Namespace(**{**vars(self.args), **utilities, **config})
+        if config_file:
+            config = self.read_cfg_file(config_file, section_in_config)
+            args.update(config)
 
     def read_cfg_file(self, config_file: str | None, section: str | None = None) -> Dict[str, Any]:
         if config_file is None:
@@ -43,13 +18,21 @@ class Configurator:
             config: Dict[str, Any] = json.load(f)
         return config if section is None else {**config["DEFAULT"], **config[section]}
 
-    def get_true_settings(self, parser: ArgumentParser, settings: Dict[str, Any], args: Namespace) -> Dict[str, Any]:
+    def get_true_settings(self, settings: Dict[str, Any], args: Dict[str, Any]) -> Dict[str, Any]:
         result: Dict[str, Any] = settings
-        dct_args = {**vars(args)}
-        for arg in dct_args:
+        for arg in args:
             if arg in settings:
-                if dct_args[arg] != parser.get_default(arg):
-                    settings[arg] = dct_args[arg]
+                if args[arg] != settings[arg]:
+                    settings[arg] = args[arg]
             else:
-                settings[arg] = dct_args[arg]
+                settings[arg] = args[arg]
         return result
+
+    def parse_args(self, args: List[str], default_params: Dict[str, Any]) -> Dict[str, Any]:
+        for i in range(0, len(args), 2):
+            key = args[i].lstrip("--").replace("-", "_")
+            value = args[i + 1]
+            if key in default_params:
+                default_params[key] = value
+
+        return default_params

--- a/src/helpers/controller.py
+++ b/src/helpers/controller.py
@@ -127,6 +127,7 @@ def init_aggregator(
 
 
 def run_utility():
+    """Execute the utility specified in command_args"""
     util_name = command_args["utility"]
     utility = command_args[util_name]
     utility.configurate(command_args)
@@ -135,6 +136,7 @@ def run_utility():
 
 class Controller:
     def __init__(self) -> None:
+        """Initialize the Controller with available utilities"""
         self.utilities: Dict[str, Utility] = {
             "generate": Generate(),
             "analyze": Analyze(),
@@ -146,5 +148,6 @@ class Controller:
             command_args[command] = self.utilities[command]
 
     def run(self) -> None:
+        """Run the application with typer"""
         command_args["configurator"] = configurator
         app()

--- a/src/helpers/controller.py
+++ b/src/helpers/controller.py
@@ -105,12 +105,6 @@ def init_aggregator(
         async_analyze: Annotated[bool, typer.Option("--async-analyze", help="Run analyze steps simultaneously "
                                                                             "(not recommended with perf)",
                                                     metavar="ASYNC_ANALYZE", show_default=False)] = True,
-        generate_arg: Annotated[str, typer.Option("--Wg", help="Pass arguments to generate", metavar="WG",
-                                                  show_default=False)] = "",
-        analyze_arg: Annotated[str, typer.Option("--Wz", help="Pass arguments to analyze", metavar="WZ",
-                                                 show_default=False)] = "",
-        summarize_arg: Annotated[str, typer.Option("--Ws", help="Pass arguments to summarize", metavar="WZ",
-                                                   show_default=False)] = "",
         log_level: Annotated[LogLevel, typer.Option(help="Log level of program")] = LogLevel.WARNING
 ):
     command_args["utility"] = "aggregate"
@@ -118,9 +112,6 @@ def init_aggregator(
     command_args["section_in_config"] = section_in_config
     command_args["dest_dir"] = dest_dir
     command_args["async_analyze"] = async_analyze
-    command_args["Wg"] = generate_arg
-    command_args["Wz"] = analyze_arg
-    command_args["Ws"] = summarize_arg
     command_args["log_level"] = log_level.value
     configurator.configurate(command_args)
     run_utility()

--- a/src/protocols/utility.py
+++ b/src/protocols/utility.py
@@ -1,14 +1,7 @@
-from argparse import ArgumentParser, Namespace
-from typing import List, Protocol
-
-from src.protocols.subparser import SubParser
+from typing import Protocol, Any, Dict
 
 
 class Utility(Protocol):
     def run(self) -> None: ...
 
-    def configurate(self, settings: Namespace) -> None: ...
-
-    def add_parser_arguments(self, subparser: SubParser) -> ArgumentParser: ...
-
-    def parse_args(self, args: List[str]) -> Namespace: ...
+    def configurate(self, settings: Dict[str, Any]) -> None: ...


### PR DESCRIPTION
- Change default argparse to typer to resolve #81
- Change Namespace to Dict because Namespace is used in argparse, and was cast to Dict a lot, so decided that it is better to get rid of Namespace